### PR TITLE
Disclaimer added and screen orientation locked

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,14 +12,18 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".AboutActivity"></activity>
+        <activity
+            android:name=".AboutActivity"
+            android:screenOrientation="portrait">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="next_dadvice">Next DadVice</string>
     <string name="cardTextValue">cardTextValue</string>
     <string name="about">About</string>
-    <string name="AboutMenuContent">"DadVice is an app created by BurritoCat. \n\nBurritoCat is a Canadian company founded in 2016 with the intention of making apps and software that stand out from the crowd. Please see our website for more information! \n\nwww.burritocat.xyz  \n\nDo you have DadVice for us? Email us at\n\nhiburritocat@gmail.com\n"</string>
+    <string name="AboutMenuContent">"<b>Disclaimer:</b> \"DadVices\" are meant for entertainment purposes only and should not be taken seriously. We are not liable for any loss or damage resulting from this app or its content.\n\nDadVice is an app created by BurritoCat. \n\nBurritoCat is a Canadian company founded in 2016, specializing in making awesome apps and software. Check us out online: www.burritocat.xyz  \n\nDo you have DadVice for us? Email us at: hiburritocat@gmail.com\n"</string>
     <string name="back">Back</string>
     <string name="ad_unit_id"> ca-app-pub-3940256099942544/1072772517</string>
 </resources>


### PR DESCRIPTION
Added a disclaimer to the "About" activity. Locked the screen
orientation of both "Main" and "About" activity to "Portrait" because
everytime the phone goes into landscape, the DadVices are shuffled and
displayed in a different order.